### PR TITLE
Makes Audit interface compatible with Laravel and MongoDB

### DIFF
--- a/src/Contracts/Audit.php
+++ b/src/Contracts/Audit.php
@@ -16,7 +16,7 @@ interface Audit
      *
      * @return string
      */
-    public function getTable(): string;
+    public function getTable();
 
     /**
      * Get the auditable model to which this Audit belongs.


### PR DESCRIPTION
Tried to reproduce the [MongoDB Audit model example](http://www.laravel-auditing.com/docs/9.0/audit-implementation) without success, because it says the interfaces are not compatible.

Just in time for Hacktoberfest, this PR fixes the issue.

[The Laravel `getTable()` definition](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Model.php#L1373):
```php
    public function getTable()
    {
        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
    }
```

[The Laravel MongoDB `getTable()` definition](https://github.com/jenssegers/laravel-mongodb/blob/master/src/Jenssegers/Mongodb/Eloquent/Model.php#L133):
```php
    public function getTable()
    {
        return $this->collection ?: parent::getTable();
    }
```

The Audit interface
```diff
- public function getTable(): string;
+ public function getTable();
```